### PR TITLE
Fixing single quotes in output

### DIFF
--- a/Source.c
+++ b/Source.c
@@ -133,7 +133,7 @@ int main(int argc, const char* * argv)
 		printf("Reading at malicious_x = %p... ", (void *)malicious_x);
 		readMemoryByte(malicious_x++, value, score);
 		printf("%s: ", (score[0] >= 2 * score[1] ? "Success" : "Unclear"));
-		printf("0x%02X=’%c’ score=%d ", value[0],
+		printf("0x%02X='%c' score=%d ", value[0],
 		       (value[0] > 31 && value[0] < 127 ? value[0] : '?'), score[0]);
 		if (score[1] > 0)
 			printf("(second best: 0x%02X score=%d)", value[1], score[1]);


### PR DESCRIPTION
The curly quotes in the output were rendering poorly in the Win10 command prompt. This PR changes them to regular single quotes.

Before:
<img width="366" alt="2018-01-05_12-34-14" src="https://user-images.githubusercontent.com/1609534/34620826-d2b6a608-f214-11e7-9fe3-255239c6738c.png">

After:
<img width="347" alt="2018-01-05_12-40-43" src="https://user-images.githubusercontent.com/1609534/34621070-b4b0d916-f215-11e7-96f2-4842b4a44db8.png">

  