### PR TITLE
make "junk" unsigned to shut up clang-3.5

### DIFF
--- a/Source.c
+++ b/Source.c
@@ -43,7 +43,8 @@ Analysis code
 void readMemoryByte(size_t malicious_x, uint8_t value[2], int score[2])
 {
 	static int results[256];
-	int tries, i, j, k, mix_i, junk = 0;
+	int tries, i, j, k, mix_i;
+	unsigned int junk = 0;
 	size_t training_x, x;
 	register uint64_t time1, time2;
 	volatile uint8_t* addr;


### PR DESCRIPTION
the test still completes, so the signed-ness of "junk" was not important. so, no reason to keep the warning.